### PR TITLE
Fix 180°-flipped cardinal in WarnGen "X miles <dir> of <city>" text

### DIFF
--- a/warngen/src/geo/cities.js
+++ b/warngen/src/geo/cities.js
@@ -66,7 +66,7 @@
 
     function toClosestPoint(city, stormPos) {
         var d = distanceMiles(city, stormPos);
-        var b = bearingDeg(city, stormPos);
+        var b = bearingDeg(stormPos, city);
         return {
             name:                   city.name,
             roundedDistance:        Math.round(d),


### PR DESCRIPTION
The #direction Velocity macro takes a from azimuth (bearing storm→city) and emits the opposite cardinal so the rendered phrase reads X miles \<dir\> of \<city\>. toClosestPoint in warngen/src/geo/cities.js was passing bearingDeg(city, stormPos) (city→storm), which is exactly 180° off — producing output like "19 MILES SOUTH OF LIMA" when the storm (near Kalida) was actually north of Lima. Swapping to bearingDeg(stormPos, city) fixes it. Verified with approximate Lima/Kalida coords: now yields oppositeRoundedAzimuth: 180, which #direction maps to "north".


`{
  "type": "Feature",
  "properties": {
    "exported_by": "WarnGen",
    "exported_at": "2026-05-07T14:22:26.517Z",
    "office": "IWX",
    "productId": "SVR",
    "etn": "0042",
    "template": "severeThunderstormWarning.vm",
    "composite_source": "CONUS"
  },
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      [
        [
          -84.30406357514899,
          41.107772139747446
        ],
        [
          -84.2132041401556,
          40.90035607529488
        ],
        [
          -83.8806631743915,
          40.95881126869339
        ],
        [
          -83.87944800043718,
          41.16169296378474
        ],
        [
          -84.30406357514899,
          41.107772139747446
        ]
      ]
    ]
  }
}`